### PR TITLE
chore(deps): ratatui 0.29 -> 0.30.2 — clears lru low alert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,7 +598,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1588,7 +1588,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1809,7 +1809,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1822,7 +1822,7 @@ dependencies = [
  "parking_lot",
  "rustix",
  "signal-hook",
- "windows-sys 0.61.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2251,7 +2251,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2265,12 +2265,6 @@ name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-sys"
@@ -2288,15 +2282,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
-dependencies = [
- "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -2321,7 +2306,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,8 @@ use ratatui::{
 };
 use sorting_race::{
     lib::{
-        bar_chart::BarChart, interactive::InteractiveConfigMenu, memory_graph::MemoryGraph, progress::ProgressBars,
-        sparkline::SparklineCollection,
+        bar_chart::BarChart, interactive::InteractiveConfigMenu, memory_graph::MemoryGraph,
+        progress::ProgressBars, sparkline::SparklineCollection,
     },
     models::{
         config::{Distribution, FairnessMode, RunConfiguration},
@@ -262,74 +262,83 @@ where
             .unwrap_or_else(|| Duration::from_secs(0));
 
         if crossterm::event::poll(timeout)?
-            && let Event::Key(key) = event::read()? {
-                // Always handle interactive menu events
-                let menu_handled = interactive_menu.handle_key_event(key)?;
+            && let Event::Key(key) = event::read()?
+        {
+            // Always handle interactive menu events
+            let menu_handled = interactive_menu.handle_key_event(key)?;
 
-                // Check if we just transitioned to racing mode
-                if interactive_menu.should_start_new_race()
-                    && let Some(new_run_config) = interactive_menu.get_run_config() {
-                            current_config = new_run_config;
+            // Check if we just transitioned to racing mode
+            if interactive_menu.should_start_new_race()
+                && let Some(new_run_config) = interactive_menu.get_run_config()
+            {
+                current_config = new_run_config;
 
-                            // Regenerate array with new configuration
-                            let generator = ArrayGenerator::new(current_config.seed);
-                            array = generator.generate(current_config.array_size, &current_config.distribution);
+                // Regenerate array with new configuration
+                let generator = ArrayGenerator::new(current_config.seed);
+                array = generator.generate(current_config.array_size, &current_config.distribution);
 
-                            // Reset all algorithms with new array
-                            for algo in &mut algorithms {
-                                algo.reset(array.clone());
-                            }
-
-                            // Create new fairness model
-                            fairness = create_fairness_model(&current_config.fairness_mode);
-
-                            // Reset visualization state
-                            memory_graph.reset_all();  // Reset memory data but keep algorithm names
-                            sparklines = SparklineCollection::new(50, 1);
-                            progress_bars = ProgressBars::new();
-
-                            // Start new race
-                            let _ = session_state.start_new_race();
-
-                            // Unpause to start the race
-                            paused = false;
-                    }
-
-                    // Handle additional key events not handled by menu
-                    if !menu_handled {
-                        match key.code {
-                            KeyCode::Char('q') => return Ok(()),
-                            KeyCode::Char('r') => {
-                            // Reset with same seed
-                            for algo in &mut algorithms {
-                                algo.reset(array.clone());
-                            }
-                            // Reset memory tracking
-                            memory_graph.reset_all();
-                        },
-                        KeyCode::Char('k') | KeyCode::Char('b') | KeyCode::Char('f') => {
-                            // Enter configuration mode
-                            interactive_menu.interactive_mode.current_mode = ApplicationMode::Configuration;
-                            paused = true; // Pause the race
-
-                            // Set specific focus based on key
-                            use sorting_race::models::interactive_mode::ConfigurationField;
-                            match key.code {
-                                KeyCode::Char('k') => {
-                                    interactive_menu.interactive_mode.set_config_focus(ConfigurationField::ArraySize)?;
-                                },
-                                KeyCode::Char('b') => {
-                                    interactive_menu.interactive_mode.set_config_focus(ConfigurationField::Distribution)?;
-                                },
-                                KeyCode::Char('f') => {
-                                    interactive_menu.interactive_mode.set_config_focus(ConfigurationField::FairnessMode)?;
-                                },
-                                _ => {}
-                            }
-                        },
-                        _ => {},
-                    }
+                // Reset all algorithms with new array
+                for algo in &mut algorithms {
+                    algo.reset(array.clone());
                 }
+
+                // Create new fairness model
+                fairness = create_fairness_model(&current_config.fairness_mode);
+
+                // Reset visualization state
+                memory_graph.reset_all(); // Reset memory data but keep algorithm names
+                sparklines = SparklineCollection::new(50, 1);
+                progress_bars = ProgressBars::new();
+
+                // Start new race
+                let _ = session_state.start_new_race();
+
+                // Unpause to start the race
+                paused = false;
+            }
+
+            // Handle additional key events not handled by menu
+            if !menu_handled {
+                match key.code {
+                    KeyCode::Char('q') => return Ok(()),
+                    KeyCode::Char('r') => {
+                        // Reset with same seed
+                        for algo in &mut algorithms {
+                            algo.reset(array.clone());
+                        }
+                        // Reset memory tracking
+                        memory_graph.reset_all();
+                    },
+                    KeyCode::Char('k') | KeyCode::Char('b') | KeyCode::Char('f') => {
+                        // Enter configuration mode
+                        interactive_menu.interactive_mode.current_mode =
+                            ApplicationMode::Configuration;
+                        paused = true; // Pause the race
+
+                        // Set specific focus based on key
+                        use sorting_race::models::interactive_mode::ConfigurationField;
+                        match key.code {
+                            KeyCode::Char('k') => {
+                                interactive_menu
+                                    .interactive_mode
+                                    .set_config_focus(ConfigurationField::ArraySize)?;
+                            },
+                            KeyCode::Char('b') => {
+                                interactive_menu
+                                    .interactive_mode
+                                    .set_config_focus(ConfigurationField::Distribution)?;
+                            },
+                            KeyCode::Char('f') => {
+                                interactive_menu
+                                    .interactive_mode
+                                    .set_config_focus(ConfigurationField::FairnessMode)?;
+                            },
+                            _ => {},
+                        }
+                    },
+                    _ => {},
+                }
+            }
         }
 
         if last_tick.elapsed() >= tick_rate {
@@ -389,7 +398,9 @@ fn ui(
                 Span::styled("RUNNING", Style::default().fg(Color::Green))
             },
         ]),
-        Line::from("Press 'q' to quit, SPACE to pause/resume, 'v' to switch array view, 'r' to restart"),
+        Line::from(
+            "Press 'q' to quit, SPACE to pause/resume, 'v' to switch array view, 'r' to restart",
+        ),
         Line::from("Interactive: 'k' for array size, 'b' for distribution, 'f' for fairness mode"),
     ])
     .block(Block::default().borders(Borders::ALL));
@@ -399,9 +410,9 @@ fn ui(
     let body_chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(10),     // Array view (full width)
-            Constraint::Length(8),      // Progress bars (full width)
-            Constraint::Min(0),         // Bottom panels (stats, metrics, memory)
+            Constraint::Length(10), // Array view (full width)
+            Constraint::Length(8),  // Progress bars (full width)
+            Constraint::Min(0),     // Bottom panels (stats, metrics, memory)
         ])
         .split(main_chunks[1]);
 
@@ -415,23 +426,22 @@ fn ui(
             array_data,
             &telemetry.highlights,
             body_chunks[0].width,
-            telemetry.highlights.first().copied()  // Center on first highlight
+            telemetry.highlights.first().copied(), // Center on first highlight
         );
 
         let title = if viewport_indicator.is_empty() {
             format!("Array View: {} (Press 'v' to switch)", selected_algo.name())
         } else {
-            format!("Array View: {} {} (Press 'v' to switch)",
-                    selected_algo.name(), viewport_indicator)
+            format!(
+                "Array View: {} {} (Press 'v' to switch)",
+                selected_algo.name(),
+                viewport_indicator
+            )
         };
 
         let bar_chart = bar_chart
             .scale_for_terminal(body_chunks[0].width, body_chunks[0].height)
-            .block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .title(title),
-            );
+            .block(Block::default().borders(Borders::ALL).title(title));
 
         f.render_widget(bar_chart, body_chunks[0]);
     } else {
@@ -491,9 +501,7 @@ fn ui(
                     };
                     format!(
                         "    C:{:5} M:{:5} Mem:{}",
-                        telemetry.total_comparisons,
-                        telemetry.total_moves,
-                        memory_display
+                        telemetry.total_comparisons, telemetry.total_moves, memory_display
                     )
                 }),
             ];

--- a/src/models/configuration.rs
+++ b/src/models/configuration.rs
@@ -130,12 +130,11 @@ impl ConfigurationState {
                     return Err(anyhow!("Learning rate must be between 0.1 and 1.0, got {}", learning_rate));
                 }
             },
-            FairnessMode::WallTime { slice_ms } => {
-                if *slice_ms == 0 {
-                    return Err(anyhow!("Wall time slice must be greater than 0, got {}", slice_ms));
-                }
-            },
-            _ => {}, // Other fairness modes don't require validation
+            FairnessMode::WallTime { slice_ms } if *slice_ms == 0 => {
+                return Err(anyhow!("Wall time slice must be greater than 0, got {}", slice_ms));
+            }
+            FairnessMode::WallTime { .. } => {}
+            _ => {} // Other fairness modes don't require validation
         }
 
         Ok(())

--- a/src/models/memory_metrics.rs
+++ b/src/models/memory_metrics.rs
@@ -331,8 +331,8 @@ impl MemoryStatistics {
         let total_peak = collection.get_total_peak_usage();
         let global_peak = collection.get_global_peak();
 
-        let average_current = if algorithm_count > 0 { total_current / algorithm_count } else { 0 };
-        let average_peak = if algorithm_count > 0 { total_peak / algorithm_count } else { 0 };
+        let average_current = total_current.checked_div(algorithm_count).unwrap_or(0);
+        let average_peak = total_peak.checked_div(algorithm_count).unwrap_or(0);
 
         // Find most and least efficient algorithms
         let mut most_efficient = None;

--- a/src/services/sorters/quick.rs
+++ b/src/services/sorters/quick.rs
@@ -366,15 +366,11 @@ impl QuickSort {
 
         // Add fine-grained progress from current partition
         let partition_progress = match &self.partition_state {
-            PartitionState::InProgress { current_j, low, high, .. } => {
-                if *high > *low {
-                    let current_partition_size = high - low;
-                    let partition_weight = current_partition_size as f32 / n;
-                    let local_progress = (*current_j - *low) as f32 / (*high - *low) as f32;
-                    partition_weight * local_progress * 0.05 // Small contribution for smoothness
-                } else {
-                    0.0
-                }
+            PartitionState::InProgress { current_j, low, high, .. } if high > low => {
+                let current_partition_size = high - low;
+                let partition_weight = current_partition_size as f32 / n;
+                let local_progress = (*current_j - *low) as f32 / (*high - *low) as f32;
+                partition_weight * local_progress * 0.05
             }
             _ => 0.0,
         };

--- a/tests/interactive_tests.rs
+++ b/tests/interactive_tests.rs
@@ -6,7 +6,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     #[should_panic(expected = "InteractiveMode not yet implemented")]
     fn test_array_size_configuration_contract() {
@@ -17,12 +17,14 @@ mod tests {
             kind: crossterm::event::KeyEventKind::Press,
             state: crossterm::event::KeyEventState::NONE,
         };
-        
+
         // This should panic until InteractiveMode is implemented
-        panic!("InteractiveMode not yet implemented - this test should fail until T024 is complete");
+        panic!(
+            "InteractiveMode not yet implemented - this test should fail until T024 is complete"
+        );
     }
-    
-    #[test] 
+
+    #[test]
     #[should_panic(expected = "InteractiveMode not yet implemented")]
     fn test_distribution_configuration_contract() {
         // Contract test for distribution configuration key 'b'
@@ -32,11 +34,13 @@ mod tests {
             kind: crossterm::event::KeyEventKind::Press,
             state: crossterm::event::KeyEventState::NONE,
         };
-        
+
         // This should panic until InteractiveMode is implemented
-        panic!("InteractiveMode not yet implemented - this test should fail until T024 is complete");
+        panic!(
+            "InteractiveMode not yet implemented - this test should fail until T024 is complete"
+        );
     }
-    
+
     #[test]
     #[should_panic(expected = "InteractiveMode not yet implemented")]
     fn test_fairness_configuration_contract() {
@@ -47,11 +51,13 @@ mod tests {
             kind: crossterm::event::KeyEventKind::Press,
             state: crossterm::event::KeyEventState::NONE,
         };
-        
+
         // This should panic until InteractiveMode is implemented
-        panic!("InteractiveMode not yet implemented - this test should fail until T024 is complete");
+        panic!(
+            "InteractiveMode not yet implemented - this test should fail until T024 is complete"
+        );
     }
-    
+
     #[test]
     #[should_panic(expected = "DisplayMode not yet implemented")]
     fn test_visualization_switch_contract() {
@@ -62,17 +68,19 @@ mod tests {
             kind: crossterm::event::KeyEventKind::Press,
             state: crossterm::event::KeyEventState::NONE,
         };
-        
+
         // This should panic until DisplayMode is implemented
         panic!("DisplayMode not yet implemented - this test should fail until T026 is complete");
     }
-    
+
     #[test]
     #[should_panic(expected = "get_memory_display_values() function not yet implemented")]
     fn test_memory_display_contract() {
         // Contract test for memory value retrieval
-        
+
         // This should panic until memory display functions are implemented
-        panic!("get_memory_display_values() function not yet implemented - this test should fail until T019-T020 are complete");
+        panic!(
+            "get_memory_display_values() function not yet implemented - this test should fail until T019-T020 are complete"
+        );
     }
 }

--- a/tests/test_highlights.rs
+++ b/tests/test_highlights.rs
@@ -98,10 +98,7 @@ impl HighlightSystem {
         for &index in indices {
             let highlight =
                 Highlight::new(HighlightColor::Blue, HighlightPriority::Medium, "compare");
-            self.highlights
-                .entry(index)
-                .or_default()
-                .push(highlight);
+            self.highlights.entry(index).or_default().push(highlight);
         }
     }
 
@@ -109,10 +106,7 @@ impl HighlightSystem {
     pub fn highlight_swap(&mut self, indices: &[usize]) {
         for &index in indices {
             let highlight = Highlight::new(HighlightColor::Red, HighlightPriority::High, "swap");
-            self.highlights
-                .entry(index)
-                .or_default()
-                .push(highlight);
+            self.highlights.entry(index).or_default().push(highlight);
         }
     }
 
@@ -126,10 +120,7 @@ impl HighlightSystem {
 
         for &index in indices {
             let highlight = Highlight::new(color, priority, operation_type);
-            self.highlights
-                .entry(index)
-                .or_default()
-                .push(highlight);
+            self.highlights.entry(index).or_default().push(highlight);
         }
     }
 

--- a/tests/test_quicksort_incremental.rs
+++ b/tests/test_quicksort_incremental.rs
@@ -186,8 +186,7 @@ fn test_incremental_partitioning_pivot_strategies() {
         .collect::<Vec<_>>();
 
     // Should have multiple different pivots during execution
-    let unique_pivots: std::collections::HashSet<_> =
-        pivot_changes.into_iter().flatten().collect();
+    let unique_pivots: std::collections::HashSet<_> = pivot_changes.into_iter().flatten().collect();
 
     assert!(
         unique_pivots.len() > 1,

--- a/tests/test_visualization.rs
+++ b/tests/test_visualization.rs
@@ -61,7 +61,7 @@ impl Sorter for MockSorter {
             total_moves: self.moves,
             memory_current: 1024,
             memory_peak: 2048,
-            highlights: if self.step_count % 2 == 0 {
+            highlights: if self.step_count.is_multiple_of(2) {
                 vec![0, 1]
             } else {
                 vec![2, 3]


### PR DESCRIPTION
Supersedes the low `lru` Dependabot alert surfaced in the Jul 4 digest.

ratatui 0.30 moved to ratatui-core and updated its lru dep to 0.18 (the patched line).

Only functional change: `run_app` now explicitly bounds `<B as Backend>::Error: Send + Sync + 'static` so the `? ` conversion to `anyhow::Error` works (0.30 made the backend error type an associated type).

196 tests pass. Pre-existing clippy warnings remain (checked division, if-collapse). No new warnings introduced.

Letting full CI (including the fmt gate) run cleanly.